### PR TITLE
test: 동시성 테스트 개선 및 예약 재고 검증 로직 반영

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        hbm2ddl:
+          halt_on_error: false
     hibernate:
       ddl-auto: create
 

--- a/src/main/resources/sql/database-data.sql
+++ b/src/main/resources/sql/database-data.sql
@@ -1,10 +1,16 @@
 -- 사용자 데이터 삽입
-INSERT INTO user_info (id, name, phone) VALUES
-    (1, '이철진', '010-1234-5678'),
-    (2, '이규명', '010-2345-6789'),
-    (3, '윤성민', '010-3456-7890'),
-    (4, '이정기', '010-4567-8901'),
-    (5, '김현진', '010-5678-9012');
+INSERT INTO user_info (id, name, phone, grade, point, total_purchase_amount, status) VALUES
+    (1, '이철진', '010-1234-5678', 'NORMAL', 0, 0, 'ACTIVE'),
+    (2, '이규명', '010-2345-6789', 'NORMAL', 0, 0, 'ACTIVE'),
+    (3, '윤성민', '010-3456-7890', 'NORMAL', 0, 0, 'ACTIVE'),
+    (4, '이정기', '010-4567-8901', 'NORMAL', 0, 0, 'ACTIVE'),
+    (5, '김현진', '010-5678-9012', 'NORMAL', 0, 0, 'ACTIVE'),
+
+    (6, '이철진 결제 동시성', '010-1234-5678', 'NORMAL', 0, 0, 'ACTIVE');
+
+
+
+
 
 -- 각 사용자와 매핑된 balance 데이터 삽입
 -- 예시로 각 사용자에게 10000.00의 초기 잔액을 부여
@@ -13,7 +19,8 @@ INSERT INTO balance (user_id, balance) VALUES
     (2, 10000000),
     (3, 10000000),
     (4, 10000000),
-    (5, 10000000);
+    (5, 10000000),
+    (6, 10000000);
 
 
 -- 1. Product 삽입 (상품 이름: 가방)
@@ -46,75 +53,84 @@ INSERT INTO product_option (option_name, option_value, created_at, updated_at)
 VALUES ('Color', 'Red', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- 3. Product Detail 삽입 (Product와 Product Option의 ID를 참조)
-INSERT INTO product_detail (product_id, product_option_id, quantity, created_at, updated_at)
+INSERT INTO product_detail (product_id, product_option_id, quantity, reserved_quantity, created_at, updated_at)
 VALUES (
            (SELECT id FROM product WHERE name = '가방'),
            (SELECT id FROM product_option WHERE option_name = 'Color' AND option_value = 'Red'),
            50,
+           0,
            CURRENT_TIMESTAMP,
            CURRENT_TIMESTAMP
        );
 
-INSERT INTO product_detail (product_id, product_option_id, quantity, created_at, updated_at)
+INSERT INTO product_detail (product_id, product_option_id, quantity, reserved_quantity, created_at, updated_at)
 VALUES (
            (SELECT id FROM product WHERE name = '신발'),
            (SELECT id FROM product_option WHERE option_name = 'Color' AND option_value = 'Red'),
            10,
+           0,
            CURRENT_TIMESTAMP,
            CURRENT_TIMESTAMP
        );
 
-INSERT INTO product_detail (product_id, product_option_id, quantity, created_at, updated_at)
+INSERT INTO product_detail (product_id, product_option_id, quantity, reserved_quantity, created_at, updated_at)
 VALUES (
            (SELECT id FROM product WHERE name = '옷'),
            (SELECT id FROM product_option WHERE option_name = 'Color' AND option_value = 'Red'),
            1,
+           0,
            CURRENT_TIMESTAMP,
            CURRENT_TIMESTAMP
        );
 
-INSERT INTO product_detail (product_id, product_option_id, quantity, created_at, updated_at)
+INSERT INTO product_detail (product_id, product_option_id, quantity, reserved_quantity, created_at, updated_at)
 VALUES (
            (SELECT id FROM product WHERE name = '책'),
            (SELECT id FROM product_option WHERE option_name = 'Color' AND option_value = 'Red'),
            1,
+           0,
            CURRENT_TIMESTAMP,
            CURRENT_TIMESTAMP
        );
 
-INSERT INTO product_detail (product_id, product_option_id, quantity, created_at, updated_at)
+INSERT INTO product_detail (product_id, product_option_id, quantity, reserved_quantity, created_at, updated_at)
 VALUES (
            (SELECT id FROM product WHERE name = '식탁'),
            (SELECT id FROM product_option WHERE option_name = 'Color' AND option_value = 'Red'),
            1,
+           0,
            CURRENT_TIMESTAMP,
            CURRENT_TIMESTAMP
        );
 
-INSERT INTO product_detail (product_id, product_option_id, quantity, created_at, updated_at)
+INSERT INTO product_detail (product_id, product_option_id, quantity, reserved_quantity, created_at, updated_at)
 VALUES (
            (SELECT id FROM product WHERE name = 'TV'),
            (SELECT id FROM product_option WHERE option_name = 'Color' AND option_value = 'Red'),
            1,
+           0,
            CURRENT_TIMESTAMP,
            CURRENT_TIMESTAMP
        );
 
-INSERT INTO product_detail (product_id, product_option_id, quantity, created_at, updated_at)
+INSERT INTO product_detail (product_id, product_option_id, quantity, reserved_quantity, created_at, updated_at)
 VALUES (
            (SELECT id FROM product WHERE name = '에어컨'),
            (SELECT id FROM product_option WHERE option_name = 'Color' AND option_value = 'Red'),
            1,
+           0,
            CURRENT_TIMESTAMP,
            CURRENT_TIMESTAMP
        );
 
-INSERT INTO product_detail (product_id, product_option_id, quantity, created_at, updated_at)
+INSERT INTO product_detail (product_id, product_option_id, quantity, reserved_quantity, created_at, updated_at)
 VALUES (
            (SELECT id FROM product WHERE name = '장롱'),
            (SELECT id FROM product_option WHERE option_name = 'Color' AND option_value = 'Red'),
            1,
+           0,
            CURRENT_TIMESTAMP,
            CURRENT_TIMESTAMP
        );
+
 

--- a/src/test/kotlin/com/hhplus/ecommerce/OrderConcurrencyTest.kt
+++ b/src/test/kotlin/com/hhplus/ecommerce/OrderConcurrencyTest.kt
@@ -46,7 +46,7 @@ class OrderConcurrencyTest: IntegrationConfig() {
                     // 모든 스레드가 준비될 때까지 대기
                     readyLatch.await()
 
-                    val detailCommand = OrderDetailCreation(3L, 1, 100)
+                    val detailCommand = OrderDetailCreation(4L, 1, 100)
 
                     // 요청마다 같은 상품 ID를 사용하여 LectureCommandData 생성
                     val command = OrderCreation(i.toLong(), listOf(detailCommand))
@@ -73,7 +73,7 @@ class OrderConcurrencyTest: IntegrationConfig() {
 
         Thread.sleep(500)
 
-        val productDetail = productRepository.findById(3).get()
+        val productDetail = productRepository.findById(4).get()
 
         for (i in 1..totalRequests) {
             val orderInfo = orderRepository.findById(i.toLong())
@@ -84,7 +84,7 @@ class OrderConcurrencyTest: IntegrationConfig() {
             }
         }
 
-        assertEquals(productDetail.quantity, 0) // 수량이 남았는지 검사
+        assertEquals(productDetail.reservedQuantity, 1) // 예약 재고 수량이 1개인지 검사
         assertEquals(successUserIds.size, 1) // 5건의 요청중 가장 먼저 처리된건이 성공한다.
         assertEquals(errorUserIds.size, 4) // 나머지 요청은 실패한다.
     }

--- a/src/test/kotlin/com/hhplus/ecommerce/PaymentConcurrencyTest.kt
+++ b/src/test/kotlin/com/hhplus/ecommerce/PaymentConcurrencyTest.kt
@@ -34,8 +34,9 @@ class PaymentConcurrencyTest: IntegrationConfig() {
     @Test
     fun concurrencyDuplicationTest() {
         val totalRequests = 3
+        val userId = 6L
 
-        val balanceQuery = BalanceQuery(1)
+        val balanceQuery = BalanceQuery(userId)
 
         val original = balanceService.getBalance(balanceQuery)
 
@@ -54,17 +55,17 @@ class PaymentConcurrencyTest: IntegrationConfig() {
                     readyLatch.await()
 
                     val orderDetailCommand = OrderDetailCreation(
-                        i.toLong()+1, 1, 100
+                        i.toLong(), 1, 100
                     )
 
-                    val orderCommand = OrderCreation(1, details = listOf(orderDetailCommand))
+                    val orderCommand = OrderCreation(userId, details = listOf(orderDetailCommand))
 
                     // 주문 신청
                     val order = orderFacade.order(orderCommand)
 
                     val payCommand = PaymentCreation(
                         orderId = order.orderId,
-                        userId = 1
+                        userId
                     )
 
                     // 결제

--- a/src/test/kotlin/com/hhplus/ecommerce/facade/OrderFacadeTest.kt
+++ b/src/test/kotlin/com/hhplus/ecommerce/facade/OrderFacadeTest.kt
@@ -106,19 +106,6 @@ class OrderFacadeTest {
 
         BDDMockito.given(orderService.order(orderCommand)).willReturn(orderResult)
 
-//        val cartQuery = ProductIdCartQuery(
-//            productId = productResult.productId
-//        )
-//
-//        val cartResult = CartResult(
-//            cartId = 5,
-//            userId = userResult.userId,
-//            productId = productResult.productId,
-//            quantity = 1
-//        )
-//
-//        BDDMockito.given(cartService.getCartByProduct(cartQuery)).willReturn(cartResult)
-
         val orderDetailCreation = OrderDetailCreation(
             productId = productResult.productId,
             price = orderDetailCommand.price,


### PR DESCRIPTION
## Summary
- `OrderConcurrencyTest`: `quantity == 0` 검증에서 `reservedQuantity == 1` 기반 검증으로 변경, productId 3→4
- `PaymentConcurrencyTest`: 기존 userId=1 하드코딩 제거, 전용 유저(id=6) 사용으로 테스트 격리
- `database-data.sql`: user_info 컬럼 확장(grade, point, status 등), product_detail에 reserved_quantity 컬럼 추가, 결제 동시성 테스트용 유저(id=6) 추가
- `application.yml`: Hibernate hbm2ddl.halt_on_error false 설정 추가
- `OrderFacadeTest`: 불필요한 주석 처리 cart 코드 제거

## Test plan
- [x] `./gradlew test --tests "OrderConcurrencyTest"`
- [x] `./gradlew test --tests "PaymentConcurrencyTest"`
- [x] `./gradlew test --tests "OrderFacadeTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)