### PR TITLE
perf: Redisson 분산락 기반 3-way 성능 비교 및 Redis 재고 예약 시스템 전환

### DIFF
--- a/docs/http/balance_request.http
+++ b/docs/http/balance_request.http
@@ -1,0 +1,18 @@
+### 잔액 충전
+PATCH http://localhost:8888/api/v1/balance/charge
+Content-Type: application/json
+
+{
+  "userId": 1,
+  "amount": 10000
+}
+
+###
+
+### 잔액 조회
+GET http://localhost:8888/api/v1/balance
+Content-Type: application/json
+
+{
+  "userId": 1
+}

--- a/docs/http/cart_request.http
+++ b/docs/http/cart_request.http
@@ -1,0 +1,29 @@
+### 장바구니 상품 추가
+POST http://localhost:8888/api/v1/cart
+Content-Type: application/json
+
+{
+  "userId": 1,
+  "productId": 1,
+  "quantity": 2
+}
+
+###
+
+### 장바구니 상품 삭제
+DELETE http://localhost:8888/api/v1/cart
+Content-Type: application/json
+
+{
+  "cartId": 1
+}
+
+###
+
+### 장바구니 목록 조회
+GET http://localhost:8888/api/v1/cart/list
+Content-Type: application/json
+
+{
+  "userId": 1
+}

--- a/docs/http/coupon_request.http
+++ b/docs/http/coupon_request.http
@@ -1,0 +1,12 @@
+### 쿠폰 발급
+POST http://localhost:8888/api/v1/coupon/1/issue
+Content-Type: application/json
+
+{
+  "userId": 1
+}
+
+###
+
+### 내 쿠폰 목록 조회
+GET http://localhost:8888/api/v1/coupon/my?userId=1

--- a/docs/http/order_request.http
+++ b/docs/http/order_request.http
@@ -1,13 +1,14 @@
-POST http://localhost:8888/order
+### 주문 생성
+POST http://localhost:8888/api/v1/order
 Content-Type: application/json
 
 {
   "userId": 1,
   "details": [
     {
-      "productId": 3,
-      "quantity": 1,
-      "price": 1000
+      "productId": 1,
+      "quantity": 2,
+      "price": 10000
     }
   ]
 }

--- a/docs/http/pay_request.http
+++ b/docs/http/pay_request.http
@@ -1,7 +1,25 @@
-POST http://localhost:8888/payment
+### 결제 처리 (잔액 전액 차감)
+POST http://localhost:8888/api/v1/payment
 Content-Type: application/json
 
 {
   "orderId": 1,
   "userId": 1
+}
+
+###
+
+### 결제 처리 (복합 결제 - 잔액 + 포인트 + 쿠폰 할인)
+POST http://localhost:8888/api/v1/payment
+Content-Type: application/json
+
+{
+  "orderId": 1,
+  "userId": 1,
+  "breakdown": {
+    "balanceAmount": 8000,
+    "pointAmount": 1000,
+    "cardAmount": 0,
+    "couponDiscount": 1000
+  }
 }

--- a/docs/http/product_request.http
+++ b/docs/http/product_request.http
@@ -1,0 +1,17 @@
+### 상품 조회 (캐시)
+GET http://localhost:8888/api/v1/product/cache?productId=1
+
+###
+
+### 상품 조회 (DB)
+GET http://localhost:8888/api/v1/product/db?productId=1
+
+###
+
+### 인기 상품 TOP 5 조회 (캐시) - 최근 3일 기준
+GET http://localhost:8888/api/v1/product/list/top_five/cache
+
+###
+
+### 인기 상품 TOP 5 조회 (DB) - 최근 3일 기준
+GET http://localhost:8888/api/v1/product/list/top_five/db

--- a/docs/http/shipment_request.http
+++ b/docs/http/shipment_request.http
@@ -1,0 +1,2 @@
+### 배송 상태 조회
+GET http://localhost:8888/api/v1/shipment/1

--- a/docs/http/user_address_request.http
+++ b/docs/http/user_address_request.http
@@ -1,0 +1,39 @@
+### 배송지 추가
+POST http://localhost:8888/api/v1/user/address
+Content-Type: application/json
+
+{
+  "userId": 1,
+  "alias": "집",
+  "receiverName": "홍길동",
+  "phone": "010-1234-5678",
+  "address": "서울특별시 강남구 테헤란로 123",
+  "zipCode": "06234",
+  "isDefault": true
+}
+
+###
+
+### 배송지 수정
+PUT http://localhost:8888/api/v1/user/address/1
+Content-Type: application/json
+
+{
+  "userId": 1,
+  "alias": "회사",
+  "receiverName": "홍길동",
+  "phone": "010-1234-5678",
+  "address": "서울특별시 서초구 서초대로 456",
+  "zipCode": "06626",
+  "isDefault": false
+}
+
+###
+
+### 배송지 삭제
+DELETE http://localhost:8888/api/v1/user/address/1
+
+###
+
+### 배송지 목록 조회
+GET http://localhost:8888/api/v1/user/address?userId=1

--- a/performance/perf-balance-charge.js
+++ b/performance/perf-balance-charge.js
@@ -8,7 +8,7 @@ export const options = {
 };
 
 export default function () {
-    const url = 'http://localhost:8080/balance/charge';
+    const url = 'http://localhost:8080/api/v1/balance/charge';
 
     const payload = JSON.stringify({
         userId: 1,

--- a/performance/perf-order.js
+++ b/performance/perf-order.js
@@ -24,7 +24,7 @@ export let options = {
     },
 };
 
-const BASE_URL = 'http://localhost:8080';
+const BASE_URL = 'http://localhost:8080/api/v1';
 
 export default function () {
     // 주문 API 호출

--- a/performance/perf-product-cache.js
+++ b/performance/perf-product-cache.js
@@ -7,7 +7,7 @@ export let options = {
     ],
 };
 
-const BASE_URL = 'http://localhost:8080';
+const BASE_URL = 'http://localhost:8080/api/v1';
 
 export default function () {
     // 캐시 조회 엔드포인트

--- a/performance/perf-product-db.js
+++ b/performance/perf-product-db.js
@@ -9,7 +9,7 @@ export let options = {
     ],
 };
 
-const BASE_URL = 'http://localhost:8080';
+const BASE_URL = 'http://localhost:8080/api/v1';
 
 export default function () {
     // DB 조회 엔드포인트

--- a/performance/perf_order.js
+++ b/performance/perf_order.js
@@ -1,15 +1,16 @@
 import http from 'k6/http';
-import { sleep, check } from 'k6';
+import { check } from 'k6';
 
 export let options = {
     scenarios: {
-        order_test: {
-            executor: 'constant-arrival-rate',
-            rate: 100, // 초당 50개의 요청
-            timeUnit: '1s', // 요청 간격
-            duration: '1m', // 10초 동안 실행
-            preAllocatedVUs: 200, // 사전 할당된 VUs
-            maxVUs: 500, // 최대 VUs
+        order_stress: {
+            executor: 'ramping-vus',
+            startVUs: 10,
+            stages: [
+                { duration: '30s', target: 100 },
+                { duration: '30s', target: 200 },
+                { duration: '30s', target: 500 },
+            ],
         },
     },
 };
@@ -37,5 +38,4 @@ export default function () {
         'Order response time < 500ms': (r) => r.timings.duration < 500,
     });
 
-    sleep(0.1); // 요청 간 짧은 간격
 }

--- a/performance/perf_order.js
+++ b/performance/perf_order.js
@@ -1,29 +1,48 @@
 import http from 'k6/http';
 import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
 
+// 커스텀 메트릭
+const orderSuccess = new Counter('order_success');
+const orderStockOut = new Counter('order_stock_out');
+const orderServerError = new Counter('order_server_error');
+const orderSuccessDuration = new Trend('order_success_duration');
+
+/**
+ * 초당 부하 성능 테스트
+ *
+ * 데이터 기준:
+ * - 상품 1 (가방): 재고 10,000개 (productId=1)
+ * - 사용자 1~5: 잔액 각 10,000,000원
+ * - 상품 가격: 50,000원
+ *
+ * 초당 100건 × 90초 = 최대 9,000건 (재고 10,000건 이내)
+ */
 export let options = {
     scenarios: {
-        order_stress: {
-            executor: 'ramping-vus',
-            startVUs: 10,
-            stages: [
-                { duration: '30s', target: 100 },
-                { duration: '30s', target: 200 },
-                { duration: '30s', target: 500 },
-            ],
+        order_load: {
+            executor: 'constant-arrival-rate',
+            rate: 100,
+            timeUnit: '1s',
+            duration: '90s',
+            preAllocatedVUs: 100,
+            maxVUs: 300,
         },
+    },
+    thresholds: {
+        'order_success_duration': ['p(95)<500'],
+        'order_server_error': ['count<10'],
     },
 };
 
 const BASE_URL = 'http://localhost:8080/api/v1';
 
 export default function () {
-    // 주문 API 호출
     let payload = JSON.stringify({
-        userId: Math.floor(Math.random() * 5) + 1, // 1~5 랜덤 사용자 ID
+        userId: Math.floor(Math.random() * 5) + 1,
         details: [
             {
-                productId: 1, // 고정 상품 ID
+                productId: 1,
                 quantity: 1,
                 price: 50000,
             }
@@ -31,11 +50,20 @@ export default function () {
     });
 
     let headers = { 'Content-Type': 'application/json' };
-
     let res = http.post(`${BASE_URL}/order`, payload, { headers });
-    check(res, {
-        'Order status is 200': (r) => r.status === 200,
-        'Order response time < 500ms': (r) => r.timings.duration < 500,
-    });
 
+    if (res.status === 200) {
+        orderSuccess.add(1);
+        orderSuccessDuration.add(res.timings.duration);
+    } else if (res.status === 500) {
+        // 재고 부족 / 잔액 부족 (RepositoryException → 500)
+        orderStockOut.add(1);
+    } else {
+        orderServerError.add(1);
+    }
+
+    check(res, {
+        'Order response is valid (200 or stock-out)': (r) => r.status === 200 || r.status === 500,
+        'Success response time < 500ms': (r) => r.status !== 200 || r.timings.duration < 500,
+    });
 }

--- a/performance/perf_order.js
+++ b/performance/perf_order.js
@@ -14,15 +14,19 @@ export let options = {
     },
 };
 
-const BASE_URL = 'http://localhost:8080';
+const BASE_URL = 'http://localhost:8080/api/v1';
 
 export default function () {
     // 주문 API 호출
     let payload = JSON.stringify({
         userId: Math.floor(Math.random() * 5) + 1, // 1~5 랜덤 사용자 ID
-        productId: 1, // 고정 상품 ID
-        quantity: 1,
-        price: 1000,
+        details: [
+            {
+                productId: 1, // 고정 상품 ID
+                quantity: 1,
+                price: 50000,
+            }
+        ]
     });
 
     let headers = { 'Content-Type': 'application/json' };

--- a/performance/perf_order.js
+++ b/performance/perf_order.js
@@ -24,7 +24,7 @@ export let options = {
             executor: 'constant-arrival-rate',
             rate: 100,
             timeUnit: '1s',
-            duration: '90s',
+            duration: '60s',
             preAllocatedVUs: 100,
             maxVUs: 300,
         },

--- a/performance/perf_order_lock.js
+++ b/performance/perf_order_lock.js
@@ -1,0 +1,69 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+
+// 커스텀 메트릭
+const orderSuccess = new Counter('order_success');
+const orderStockOut = new Counter('order_stock_out');
+const orderServerError = new Counter('order_server_error');
+const orderSuccessDuration = new Trend('order_success_duration');
+
+/**
+ * Redisson 분산락 기반 주문 부하 테스트 (성능 비교용)
+ *
+ * 비교 대상:
+ * - perf_order.js      → POST /api/v1/order       (Lua 원자 스크립트 + Redis 재고)
+ * - perf_order_lock.js → POST /api/v1/order/lock  (Redisson 분산락 + MySQL reservedQuantity)
+ *
+ * 데이터 기준:
+ * - 상품 1 (가방): 재고 10,000개
+ * - 초당 100건 × 90초 = 최대 9,000건 (재고 이내)
+ */
+export let options = {
+    scenarios: {
+        order_lock_load: {
+            executor: 'constant-arrival-rate',
+            rate: 100,
+            timeUnit: '1s',
+            duration: '90s',
+            preAllocatedVUs: 100,
+            maxVUs: 300,
+        },
+    },
+    thresholds: {
+        'order_success_duration': ['p(95)<500'],
+        'order_server_error': ['count<10'],
+    },
+};
+
+const BASE_URL = 'http://localhost:8080/api/v1';
+
+export default function () {
+    let payload = JSON.stringify({
+        userId: Math.floor(Math.random() * 5) + 1,
+        details: [
+            {
+                productId: 1,
+                quantity: 1,
+                price: 50000,
+            }
+        ]
+    });
+
+    let headers = { 'Content-Type': 'application/json' };
+    let res = http.post(`${BASE_URL}/order/lock`, payload, { headers });
+
+    if (res.status === 200) {
+        orderSuccess.add(1);
+        orderSuccessDuration.add(res.timings.duration);
+    } else if (res.status === 500) {
+        orderStockOut.add(1);
+    } else {
+        orderServerError.add(1);
+    }
+
+    check(res, {
+        'Order response is valid (200 or stock-out)': (r) => r.status === 200 || r.status === 500,
+        'Success response time < 500ms': (r) => r.status !== 200 || r.timings.duration < 500,
+    });
+}

--- a/performance/perf_order_lock.js
+++ b/performance/perf_order_lock.js
@@ -17,7 +17,7 @@ const orderSuccessDuration = new Trend('order_success_duration');
  *
  * 데이터 기준:
  * - 상품 1 (가방): 재고 10,000개
- * - 초당 100건 × 90초 = 최대 9,000건 (재고 이내)
+ * - 초당 100건 × 60초 = 최대 6,000건 (재고 이내)
  */
 export let options = {
     scenarios: {
@@ -25,7 +25,7 @@ export let options = {
             executor: 'constant-arrival-rate',
             rate: 100,
             timeUnit: '1s',
-            duration: '90s',
+            duration: '60s',
             preAllocatedVUs: 100,
             maxVUs: 300,
         },

--- a/performance/perf_order_spin.js
+++ b/performance/perf_order_spin.js
@@ -1,0 +1,69 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+
+const orderSuccess = new Counter('order_success');
+const orderStockOut = new Counter('order_stock_out');
+const orderServerError = new Counter('order_server_error');
+const orderSuccessDuration = new Trend('order_success_duration');
+
+/**
+ * Redisson 스핀락 기반 주문 부하 테스트 (성능 비교용)
+ *
+ * 비교 대상:
+ * - perf_order.js      → POST /api/v1/order       (Lua 원자 스크립트)
+ * - perf_order_lock.js → POST /api/v1/order/lock  (Redisson PubSub 분산락)
+ * - perf_order_spin.js → POST /api/v1/order/spin  (Redisson 스핀락)
+ *
+ * PubSub vs Spin 차이:
+ * - PubSub: 락 해제 시 Redis pub/sub 알림으로 대기 스레드 깨움 (event-driven)
+ * - Spin:   락 획득 실패 시 exponential backoff로 polling 재시도 (busy-wait)
+ */
+export let options = {
+    scenarios: {
+        order_spin_load: {
+            executor: 'constant-arrival-rate',
+            rate: 100,
+            timeUnit: '1s',
+            duration: '90s',
+            preAllocatedVUs: 100,
+            maxVUs: 300,
+        },
+    },
+    thresholds: {
+        'order_success_duration': ['p(95)<500'],
+        'order_server_error': ['count<10'],
+    },
+};
+
+const BASE_URL = 'http://localhost:8080/api/v1';
+
+export default function () {
+    let payload = JSON.stringify({
+        userId: Math.floor(Math.random() * 5) + 1,
+        details: [
+            {
+                productId: 1,
+                quantity: 1,
+                price: 50000,
+            }
+        ]
+    });
+
+    let headers = { 'Content-Type': 'application/json' };
+    let res = http.post(`${BASE_URL}/order/spin`, payload, { headers });
+
+    if (res.status === 200) {
+        orderSuccess.add(1);
+        orderSuccessDuration.add(res.timings.duration);
+    } else if (res.status === 500) {
+        orderStockOut.add(1);
+    } else {
+        orderServerError.add(1);
+    }
+
+    check(res, {
+        'Order response is valid (200 or stock-out)': (r) => r.status === 200 || r.status === 500,
+        'Success response time < 500ms': (r) => r.status !== 200 || r.timings.duration < 500,
+    });
+}

--- a/performance/perf_order_spin.js
+++ b/performance/perf_order_spin.js
@@ -25,7 +25,7 @@ export let options = {
             executor: 'constant-arrival-rate',
             rate: 100,
             timeUnit: '1s',
-            duration: '90s',
+            duration: '60s',
             preAllocatedVUs: 100,
             maxVUs: 300,
         },

--- a/src/main/kotlin/com/hhplus/ecommerce/common/anotation/aspect/RedisLockAspect.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/common/anotation/aspect/RedisLockAspect.kt
@@ -1,7 +1,10 @@
 package com.hhplus.ecommerce.common.anotation.aspect
 
 import com.hhplus.ecommerce.common.anotation.RedisLock
+import com.hhplus.ecommerce.common.anotation.aspect.enums.RedisLockStrategy
 import com.hhplus.ecommerce.infrastructure.redis.IRedisLockSupporter
+import com.hhplus.ecommerce.infrastructure.redis.PubSubLockSupporter
+import com.hhplus.ecommerce.infrastructure.redis.SpinLockSupporter
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
@@ -19,7 +22,8 @@ import org.springframework.transaction.support.TransactionTemplate
 @Aspect
 @Component
 class RedisLockAspect(
-    private val pubSubLockSupporter: IRedisLockSupporter,
+    private val pubSubLockSupporter: PubSubLockSupporter,
+    private val spinLockSupporter: SpinLockSupporter,
     private val transactionManager: PlatformTransactionManager
 ) {
     private val logger = LoggerFactory.getLogger(RedisLockAspect::class.java)
@@ -34,8 +38,12 @@ class RedisLockAspect(
     @Around("@annotation(redisLock)")
     fun around(joinPoint: ProceedingJoinPoint, redisLock: RedisLock): Any? {
         val key = parseKey(redisLock.key, joinPoint)
+        val supporter = when (redisLock.strategy) {
+            RedisLockStrategy.SPIN -> spinLockSupporter
+            else -> pubSubLockSupporter
+        }
 
-        return pubSubLockSupporter.withLock(key) {
+        return supporter.withLock(key) {
             transactionTemplate.execute { transactionStatus ->
                 try {
                     joinPoint.proceed()

--- a/src/main/kotlin/com/hhplus/ecommerce/common/anotation/aspect/enums/RedisLockStrategy.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/common/anotation/aspect/enums/RedisLockStrategy.kt
@@ -1,5 +1,6 @@
 package com.hhplus.ecommerce.common.anotation.aspect.enums
 
 enum class RedisLockStrategy {
-    PUB_SUB
+    PUB_SUB,
+    SPIN
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/infrastructure/redis/PubSubLockSupporter.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/infrastructure/redis/PubSubLockSupporter.kt
@@ -10,7 +10,7 @@ class PubSubLockSupporter(
     private val redissonClient: RedissonClient
 ): IRedisLockSupporter {
     private val waitTime = 10L
-    private val releaseTime = 1L
+    private val releaseTime = 5L
 
     private val logger = LoggerFactory.getLogger(PubSubLockSupporter::class.java);
 
@@ -24,9 +24,12 @@ class PubSubLockSupporter(
 
         return try {
             logger.info("REDIS:PUB_SUB:ACQUIRE:INFO:$key")
-            action()  // 락 획득 성공 시 `action`의 결과 반환
+            action()
         } finally {
-            logger.info("REDIS:PUB_SUB:UNLOCK:INFO:$key")
+            if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+                logger.info("REDIS:PUB_SUB:UNLOCK:INFO:$key")
+            }
         }
     }
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/infrastructure/redis/SpinLockSupporter.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/infrastructure/redis/SpinLockSupporter.kt
@@ -1,0 +1,35 @@
+package com.hhplus.ecommerce.infrastructure.redis
+
+import org.redisson.api.RedissonClient
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class SpinLockSupporter(
+    private val redissonClient: RedissonClient
+) : IRedisLockSupporter {
+    private val waitTime = 10L
+    private val releaseTime = 5L
+
+    private val logger = LoggerFactory.getLogger(SpinLockSupporter::class.java)
+
+    override fun <T> withLock(key: String, action: () -> T): T {
+        val lock = redissonClient.getSpinLock(key)
+
+        if (!lock.tryLock(waitTime, releaseTime, TimeUnit.SECONDS)) {
+            logger.error("REDIS:SPIN:LOCK:ERROR:$key -> 락을 얻지 못 했습니다.")
+            throw IllegalStateException("Could not acquire spin lock for key: $key")
+        }
+
+        return try {
+            logger.info("REDIS:SPIN:ACQUIRE:INFO:$key")
+            action()
+        } finally {
+            if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+                logger.info("REDIS:SPIN:UNLOCK:INFO:$key")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/hhplus/ecommerce/order/api/IOrderController.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/order/api/IOrderController.kt
@@ -29,4 +29,17 @@ interface IOrderController {
     fun prepareOrder(
         @RequestBody request: OrderCreationRequest
     ): CustomApiResponse<OrderResponse>
+
+    @Tag(name = "주문 기능")
+    @Operation(summary = "주문 API (Redisson 분산락)", description = "Redisson 분산락 기반 재고 점유 주문 API (Lua 스크립트 방식과 성능 비교용)")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "주문 성공", useReturnTypeSchema = true),
+        ApiResponse(responseCode = "429", description = "요청 한도 초과", content = [Content(schema = Schema(implementation = CustomErrorResponse::class))]),
+        ApiResponse(responseCode = "500", description = "서버 오류", content = [Content(schema = Schema(implementation = CustomErrorResponse::class))]),
+    ])
+    @PostMapping("/lock")
+    @RateLimit(key = "#request.userId", limit = 20, seconds = 60)
+    fun prepareOrderWithLock(
+        @RequestBody request: OrderCreationRequest
+    ): CustomApiResponse<OrderResponse>
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/order/api/IOrderController.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/order/api/IOrderController.kt
@@ -42,4 +42,17 @@ interface IOrderController {
     fun prepareOrderWithLock(
         @RequestBody request: OrderCreationRequest
     ): CustomApiResponse<OrderResponse>
+
+    @Tag(name = "주문 기능")
+    @Operation(summary = "주문 API (Redisson 스핀락)", description = "Redisson 스핀락 기반 재고 점유 주문 API (Lua/PubSub 방식과 성능 비교용)")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "주문 성공", useReturnTypeSchema = true),
+        ApiResponse(responseCode = "429", description = "요청 한도 초과", content = [Content(schema = Schema(implementation = CustomErrorResponse::class))]),
+        ApiResponse(responseCode = "500", description = "서버 오류", content = [Content(schema = Schema(implementation = CustomErrorResponse::class))]),
+    ])
+    @PostMapping("/spin")
+    @RateLimit(key = "#request.userId", limit = 20, seconds = 60)
+    fun prepareOrderWithSpinLock(
+        @RequestBody request: OrderCreationRequest
+    ): CustomApiResponse<OrderResponse>
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/order/api/OrderController.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/order/api/OrderController.kt
@@ -12,9 +12,12 @@ class OrderController(
     private val orderFacade: OrderFacade
 ): IOrderController {
     override fun prepareOrder(request: OrderCreationRequest): CustomApiResponse<OrderResponse> {
-
         val result = orderFacade.order(request.toOrderCreation())
+        return CustomApiResponse.success(OrderResponse.from(result))
+    }
 
+    override fun prepareOrderWithLock(request: OrderCreationRequest): CustomApiResponse<OrderResponse> {
+        val result = orderFacade.orderWithLock(request.toOrderCreation())
         return CustomApiResponse.success(OrderResponse.from(result))
     }
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/order/api/OrderController.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/order/api/OrderController.kt
@@ -20,4 +20,9 @@ class OrderController(
         val result = orderFacade.orderWithLock(request.toOrderCreation())
         return CustomApiResponse.success(OrderResponse.from(result))
     }
+
+    override fun prepareOrderWithSpinLock(request: OrderCreationRequest): CustomApiResponse<OrderResponse> {
+        val result = orderFacade.orderWithSpinLock(request.toOrderCreation())
+        return CustomApiResponse.success(OrderResponse.from(result))
+    }
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/order/domain/OrderService.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/order/domain/OrderService.kt
@@ -34,9 +34,7 @@ class OrderService(
 
     @Transactional
     fun updateStatus(orderId: Long, status: OrderStatus) {
-        val entity = orderRepository.findById(orderId)
-        entity.status = status
-        orderRepository.insertOrUpdate(entity)
+        orderRepository.updateStatus(orderId, status)
     }
 
     fun findAllByStatus(status: OrderStatus): List<OrderResult> =

--- a/src/main/kotlin/com/hhplus/ecommerce/order/domain/repository/IOrderRepository.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/order/domain/repository/IOrderRepository.kt
@@ -11,5 +11,6 @@ interface IOrderRepository {
     fun findAllByStatus(status: OrderStatus): List<OrderEntity>
 
     fun insertOrUpdate(entity: OrderEntity): OrderEntity
+    fun updateStatus(orderId: Long, status: OrderStatus)
     fun deleteOrderDetail(orderId: Long, productId: Long)
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/order/infrastructure/OrderRepository.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/order/infrastructure/OrderRepository.kt
@@ -31,6 +31,11 @@ class OrderRepository(
         return orderJpaRepository.save(entity)
     }
 
+    @Transactional
+    override fun updateStatus(orderId: Long, status: OrderStatus) {
+        orderJpaRepository.updateStatusById(orderId, status)
+    }
+
     override fun findAllByStatus(status: OrderStatus): List<OrderEntity> =
         orderJpaRepository.findAllByStatus(status)
 

--- a/src/main/kotlin/com/hhplus/ecommerce/order/infrastructure/jpa/OrderJpaRepository.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/order/infrastructure/jpa/OrderJpaRepository.kt
@@ -3,7 +3,9 @@ package com.hhplus.ecommerce.order.infrastructure.jpa
 import com.hhplus.ecommerce.order.common.OrderStatus
 import com.hhplus.ecommerce.order.infrastructure.jpa.entity.OrderEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.Optional
 
 interface OrderJpaRepository: JpaRepository<OrderEntity, Long> {
@@ -11,4 +13,8 @@ interface OrderJpaRepository: JpaRepository<OrderEntity, Long> {
     fun findByIdAndStatus(id: Long, status: OrderStatus): Optional<OrderEntity>
 
     fun findAllByStatus(status: OrderStatus): List<OrderEntity>
+
+    @Modifying
+    @Query("UPDATE OrderEntity o SET o.status = :status WHERE o.id = :id")
+    fun updateStatusById(@Param("id") id: Long, @Param("status") status: OrderStatus)
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/order/usecase/OrderFacade.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/order/usecase/OrderFacade.kt
@@ -1,15 +1,12 @@
 package com.hhplus.ecommerce.order.usecase
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.hhplus.ecommerce.balance.domain.BalanceService
-import com.hhplus.ecommerce.cart.domain.CartService
-import com.hhplus.ecommerce.cart.domain.dto.CartDeletion
-import com.hhplus.ecommerce.cart.domain.dto.ProductIdCartQuery
-import com.hhplus.ecommerce.common.properties.PaymentKafkaProperties
 import com.hhplus.ecommerce.common.properties.ProductStockKafkaProperties
+import com.hhplus.ecommerce.order.common.OrderStatus
 import com.hhplus.ecommerce.order.domain.OrderService
+import com.hhplus.ecommerce.balance.domain.BalanceService
 import com.hhplus.ecommerce.product.domain.ProductService
-import com.hhplus.ecommerce.product.domain.dto.DecreaseProductDetailStock
+import com.hhplus.ecommerce.product.domain.StockReservationService
 import com.hhplus.ecommerce.user.domain.UserService
 import com.hhplus.ecommerce.notification.common.NotificationChannel
 import com.hhplus.ecommerce.notification.common.NotificationType
@@ -19,9 +16,9 @@ import com.hhplus.ecommerce.order.usecase.dto.OrderCreation
 import com.hhplus.ecommerce.order.usecase.dto.OrderInfo
 import com.hhplus.ecommerce.order.usecase.dto.ProductStockEventRequest
 import com.hhplus.ecommerce.outboxevent.infrastructure.event.dto.OutboxEventInfo
+import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 @Component
@@ -29,22 +26,38 @@ class OrderFacade(
     private val userService: UserService,
     private val balanceService: BalanceService,
     private val orderService: OrderService,
+    private val stockReservationService: StockReservationService,
+    private val productService: ProductService,
     private val applicationEventPublisher: ApplicationEventPublisher,
     private val productStockKafkaProperties: ProductStockKafkaProperties,
     private val objectMapper: ObjectMapper,
     private val notificationEventPublisher: INotificationEventPublisher,
 ) {
+    private val logger = LoggerFactory.getLogger(OrderFacade::class.java)
 
-    @Transactional
     fun order(info: OrderCreation): OrderInfo {
         val user = userService.getUserById(info.toUserQuery())
         balanceService.validateBalanceToUse(info.toBalanceTransaction())
 
+        // 주문 생성 — 자체 @Transactional로 커밋
         val order = orderService.order(info.toOrderCreationCommand())
         val result = OrderInfo.from(order)
 
-        val productEvent = ProductStockEventRequest.of(result)
+        // 트랜잭션 밖에서 재고 점유 — 각 reserve()가 자체 @Transactional로 커밋
+        try {
+            info.details.forEach { detail ->
+                val productDetail = productService.getProductDetail(detail.toProductDetailQuery())
+                stockReservationService.reserve(result.orderId, productDetail.productDetailId, detail.quantity)
+            }
+        } catch (e: Exception) {
+            logger.warn("재고 점유 실패 - orderId=${result.orderId}, 재고 해제 및 주문 취소 진행", e)
+            stockReservationService.release(result.orderId)
+            orderService.updateStatus(result.orderId, OrderStatus.CANCELED)
+            throw e
+        }
 
+        // Kafka 이벤트 — 알림/후처리 목적
+        val productEvent = ProductStockEventRequest.of(result)
         val outboxEvent = OutboxEventInfo(
             id = UUID.randomUUID(),
             groupId = productStockKafkaProperties.groupId,
@@ -53,7 +66,6 @@ class OrderFacade(
             eventType = "OrderProductStock",
             schemaVersion = "1"
         )
-
         applicationEventPublisher.publishEvent(outboxEvent)
 
         notificationEventPublisher.publish(
@@ -66,21 +78,6 @@ class OrderFacade(
                 orderId = result.orderId
             )
         )
-
-        // 주문에 대한 부가 작업이라 도메인 이벤트 발행으로 뺴는 게 좋을듯
-//        // 최근 3일 간의 Top5 캐시 갱신
-//        productService.refreshTopFiveLastThreeDays()
-//
-//        val cartQuery = ProductIdCartQuery(it.productId)
-//
-//        val cart = cartService.getCartByProduct(cartQuery)
-//
-//        if (cart != null) {
-//            val cartDeletion = CartDeletion(cart.cartId)
-//            cartService.delete(cartDeletion)
-//        }
-
-
 
         return result
     }

--- a/src/main/kotlin/com/hhplus/ecommerce/order/usecase/OrderFacade.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/order/usecase/OrderFacade.kt
@@ -135,4 +135,57 @@ class OrderFacade(
         return result
     }
 
+    /**
+     * Redisson 스핀락 기반 주문 (성능 비교용)
+     * spinLock: 락 획득 실패 시 busy-wait 방식으로 재시도 (CPU polling)
+     * pubSubLock: 락 해제 알림 수신 후 재시도 (event-driven)
+     */
+    fun orderWithSpinLock(info: OrderCreation): OrderInfo {
+        val user = userService.getUserById(info.toUserQuery())
+        balanceService.validateBalanceToUse(info.toBalanceTransaction())
+
+        val order = orderService.order(info.toOrderCreationCommand())
+        val result = OrderInfo.from(order)
+
+        val reservedDetails = mutableListOf<Pair<Long, Int>>()
+        try {
+            info.details.forEach { detail ->
+                val productDetail = productService.getProductDetail(detail.toProductDetailQuery())
+                stockReservationService.reserveWithSpinLock(result.orderId, productDetail.productDetailId, detail.quantity)
+                reservedDetails.add(productDetail.productDetailId to detail.quantity)
+            }
+        } catch (e: Exception) {
+            logger.warn("재고 점유 실패(spin) - orderId=${result.orderId}, 재고 해제 및 주문 취소 진행", e)
+            reservedDetails.forEach { (productDetailId, quantity) ->
+                stockReservationService.releaseBySpinLock(productDetailId, quantity)
+            }
+            orderService.updateStatus(result.orderId, OrderStatus.CANCELED)
+            throw e
+        }
+
+        val productEvent = ProductStockEventRequest.of(result)
+        val outboxEvent = OutboxEventInfo(
+            id = UUID.randomUUID(),
+            groupId = productStockKafkaProperties.groupId,
+            topic = productStockKafkaProperties.topic,
+            payload = objectMapper.writeValueAsString(productEvent),
+            eventType = "OrderProductStock",
+            schemaVersion = "1"
+        )
+        applicationEventPublisher.publishEvent(outboxEvent)
+
+        notificationEventPublisher.publish(
+            NotificationEvent(
+                userId = user.userId,
+                type = NotificationType.ORDER_PLACED,
+                channel = NotificationChannel.PUSH,
+                title = "주문이 접수되었습니다.",
+                body = "주문 번호 ${result.orderId}번 주문이 정상적으로 접수되었습니다.",
+                orderId = result.orderId
+            )
+        )
+
+        return result
+    }
+
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/order/usecase/OrderFacade.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/order/usecase/OrderFacade.kt
@@ -82,4 +82,57 @@ class OrderFacade(
         return result
     }
 
+    /**
+     * Redisson 분산락 기반 주문 (성능 비교용)
+     * reserve() — Lua 원자 스크립트 + Redis 재고
+     * orderWithLock() — Redisson 분산락 + MySQL reservedQuantity
+     */
+    fun orderWithLock(info: OrderCreation): OrderInfo {
+        val user = userService.getUserById(info.toUserQuery())
+        balanceService.validateBalanceToUse(info.toBalanceTransaction())
+
+        val order = orderService.order(info.toOrderCreationCommand())
+        val result = OrderInfo.from(order)
+
+        val reservedDetails = mutableListOf<Pair<Long, Int>>() // (productDetailId, quantity)
+        try {
+            info.details.forEach { detail ->
+                val productDetail = productService.getProductDetail(detail.toProductDetailQuery())
+                stockReservationService.reserveWithLock(result.orderId, productDetail.productDetailId, detail.quantity)
+                reservedDetails.add(productDetail.productDetailId to detail.quantity)
+            }
+        } catch (e: Exception) {
+            logger.warn("재고 점유 실패(lock) - orderId=${result.orderId}, 재고 해제 및 주문 취소 진행", e)
+            reservedDetails.forEach { (productDetailId, quantity) ->
+                stockReservationService.releaseByLock(productDetailId, quantity)
+            }
+            orderService.updateStatus(result.orderId, OrderStatus.CANCELED)
+            throw e
+        }
+
+        val productEvent = ProductStockEventRequest.of(result)
+        val outboxEvent = OutboxEventInfo(
+            id = UUID.randomUUID(),
+            groupId = productStockKafkaProperties.groupId,
+            topic = productStockKafkaProperties.topic,
+            payload = objectMapper.writeValueAsString(productEvent),
+            eventType = "OrderProductStock",
+            schemaVersion = "1"
+        )
+        applicationEventPublisher.publishEvent(outboxEvent)
+
+        notificationEventPublisher.publish(
+            NotificationEvent(
+                userId = user.userId,
+                type = NotificationType.ORDER_PLACED,
+                channel = NotificationChannel.PUSH,
+                title = "주문이 접수되었습니다.",
+                body = "주문 번호 ${result.orderId}번 주문이 정상적으로 접수되었습니다.",
+                orderId = result.orderId
+            )
+        )
+
+        return result
+    }
+
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/product/domain/StockReservationService.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/domain/StockReservationService.kt
@@ -1,9 +1,12 @@
 package com.hhplus.ecommerce.product.domain
 
 import com.hhplus.ecommerce.product.domain.repository.IProductDetailRepository
+import com.hhplus.ecommerce.product.domain.repository.IRedisStockRepository
 import com.hhplus.ecommerce.product.domain.repository.IStockReservationRepository
+import com.hhplus.ecommerce.product.infrastructure.exception.OutOfStockException
 import com.hhplus.ecommerce.product.infrastructure.jpa.entity.StockReservationEntity
 import com.hhplus.ecommerce.product.infrastructure.jpa.entity.StockReservationStatus
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -11,39 +14,62 @@ import java.time.LocalDateTime
 @Service
 class StockReservationService(
     private val stockReservationRepository: IStockReservationRepository,
-    private val productDetailRepository: IProductDetailRepository
+    private val productDetailRepository: IProductDetailRepository,
+    private val redisStockRepository: IRedisStockRepository
 ) {
+    private val logger = LoggerFactory.getLogger(StockReservationService::class.java)
 
     @Transactional
     fun reserve(orderId: Long, productDetailId: Long, quantity: Int): StockReservationEntity {
-        val productDetail = productDetailRepository.findById(productDetailId)
-        productDetail.reserve(quantity)
-        productDetailRepository.save(productDetail)
+        val reserved = redisStockRepository.reserve(productDetailId, quantity)
+        if (!reserved) {
+            throw OutOfStockException()
+        }
 
-        val reservation = StockReservationEntity(
-            orderId = orderId,
-            productDetailId = productDetailId,
-            quantity = quantity,
-            status = StockReservationStatus.RESERVED,
-            expiredAt = LocalDateTime.now().plusMinutes(30)
-        )
-        return stockReservationRepository.save(reservation)
+        try {
+            redisStockRepository.saveReservationInfo(orderId, productDetailId, quantity)
+
+            val reservation = StockReservationEntity(
+                orderId = orderId,
+                productDetailId = productDetailId,
+                quantity = quantity,
+                status = StockReservationStatus.RESERVED,
+                expiredAt = LocalDateTime.now().plusMinutes(30)
+            )
+            return stockReservationRepository.save(reservation)
+        } catch (e: Exception) {
+            // MySQL 이력 저장 실패 시 Redis 차감 보상
+            logger.error("STOCK:RESERVE:ROLLBACK - orderId={}, productDetailId={}", orderId, productDetailId, e)
+            redisStockRepository.release(productDetailId, quantity)
+            redisStockRepository.removeReservationInfo(orderId)
+            throw e
+        }
     }
 
     @Transactional
     fun reserveWithExpiry(orderId: Long, productDetailId: Long, quantity: Int, expiredAt: LocalDateTime): StockReservationEntity {
-        val productDetail = productDetailRepository.findById(productDetailId)
-        productDetail.reserve(quantity)
-        productDetailRepository.save(productDetail)
+        val reserved = redisStockRepository.reserve(productDetailId, quantity)
+        if (!reserved) {
+            throw OutOfStockException()
+        }
 
-        val reservation = StockReservationEntity(
-            orderId = orderId,
-            productDetailId = productDetailId,
-            quantity = quantity,
-            status = StockReservationStatus.RESERVED,
-            expiredAt = expiredAt
-        )
-        return stockReservationRepository.save(reservation)
+        try {
+            redisStockRepository.saveReservationInfo(orderId, productDetailId, quantity)
+
+            val reservation = StockReservationEntity(
+                orderId = orderId,
+                productDetailId = productDetailId,
+                quantity = quantity,
+                status = StockReservationStatus.RESERVED,
+                expiredAt = expiredAt
+            )
+            return stockReservationRepository.save(reservation)
+        } catch (e: Exception) {
+            logger.error("STOCK:RESERVE_WITH_EXPIRY:ROLLBACK - orderId={}, productDetailId={}", orderId, productDetailId, e)
+            redisStockRepository.release(productDetailId, quantity)
+            redisStockRepository.removeReservationInfo(orderId)
+            throw e
+        }
     }
 
     @Transactional
@@ -52,24 +78,26 @@ class StockReservationService(
         check(reservations.isNotEmpty()) { "orderId=$orderId 에 대한 RESERVED 예약을 찾을 수 없습니다." }
 
         reservations.forEach { reservation ->
-            val productDetail = productDetailRepository.findById(reservation.productDetailId)
-            productDetail.commit(reservation.quantity)
+            val productDetail = productDetailRepository.findByIdForUpdate(reservation.productDetailId)
+            productDetail.decreaseQuantity(reservation.quantity)
             productDetailRepository.save(productDetail)
             reservation.status = StockReservationStatus.COMMITTED
         }
         stockReservationRepository.saveAll(reservations)
+        redisStockRepository.removeReservationInfo(orderId)
     }
 
     @Transactional
     fun release(orderId: Long) {
-        val reservations = stockReservationRepository.findAllByOrderIdAndStatus(orderId, StockReservationStatus.RESERVED)
+        val reservationInfo = redisStockRepository.getReservationInfo(orderId)
 
-        reservations.forEach { reservation ->
-            val productDetail = productDetailRepository.findById(reservation.productDetailId)
-            productDetail.release(reservation.quantity)
-            productDetailRepository.save(productDetail)
-            reservation.status = StockReservationStatus.RELEASED
+        reservationInfo.forEach { (productDetailId, quantity) ->
+            redisStockRepository.release(productDetailId, quantity)
         }
+        redisStockRepository.removeReservationInfo(orderId)
+
+        val reservations = stockReservationRepository.findAllByOrderIdAndStatus(orderId, StockReservationStatus.RESERVED)
+        reservations.forEach { it.status = StockReservationStatus.RELEASED }
         stockReservationRepository.saveAll(reservations)
     }
 
@@ -79,9 +107,7 @@ class StockReservationService(
         val expiredReservations = stockReservationRepository.findAllByStatusAndExpiredAtBefore(StockReservationStatus.RESERVED, now)
 
         expiredReservations.forEach { reservation ->
-            val productDetail = productDetailRepository.findById(reservation.productDetailId)
-            productDetail.release(reservation.quantity)
-            productDetailRepository.save(productDetail)
+            redisStockRepository.release(reservation.productDetailId, reservation.quantity)
             reservation.status = StockReservationStatus.EXPIRED
         }
         stockReservationRepository.saveAll(expiredReservations)

--- a/src/main/kotlin/com/hhplus/ecommerce/product/domain/StockReservationService.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/domain/StockReservationService.kt
@@ -103,23 +103,36 @@ class StockReservationService(
     }
 
     /**
-     * Redisson 분산락 기반 재고 예약 (MySQL reservedQuantity 직접 관리)
+     * Redisson 분산락 기반 재고 예약 (Redis stock:available 직접 관리)
      * 성능 비교용: Lua 원자 스크립트 방식(reserve)과 응답시간 차이 측정
+     *
+     * reserve()     → Lua script: GET + DECRBY 원자적 수행 (락 없음)
+     * reserveWithLock() → Redisson 락으로 직렬화 후 GET + DECRBY 분리 수행
+     * 둘 다 동일한 stock:available:{id} Redis 키 사용
      */
     @RedisLock(key = "'stock:lock:' + #productDetailId")
     fun reserveWithLock(orderId: Long, productDetailId: Long, quantity: Int): StockReservationEntity {
-        val productDetail = productDetailRepository.findById(productDetailId)
-        productDetail.reserve(quantity) // availableQuantity 검사 + reservedQuantity 증가
-        productDetailRepository.save(productDetail)
+        val available = redisStockRepository.getAvailableStock(productDetailId)
+        if (available < quantity) throw OutOfStockException()
 
-        val reservation = StockReservationEntity(
-            orderId = orderId,
-            productDetailId = productDetailId,
-            quantity = quantity,
-            status = StockReservationStatus.RESERVED,
-            expiredAt = LocalDateTime.now().plusMinutes(30)
-        )
-        return stockReservationRepository.save(reservation)
+        redisStockRepository.decreaseStock(productDetailId, quantity)
+
+        try {
+            redisStockRepository.saveReservationInfo(orderId, productDetailId, quantity)
+            val reservation = StockReservationEntity(
+                orderId = orderId,
+                productDetailId = productDetailId,
+                quantity = quantity,
+                status = StockReservationStatus.RESERVED,
+                expiredAt = LocalDateTime.now().plusMinutes(30)
+            )
+            return stockReservationRepository.save(reservation)
+        } catch (e: Exception) {
+            logger.error("STOCK:RESERVE_WITH_LOCK:ROLLBACK - orderId={}, productDetailId={}", orderId, productDetailId, e)
+            redisStockRepository.increaseStock(productDetailId, quantity)
+            redisStockRepository.removeReservationInfo(orderId)
+            throw e
+        }
     }
 
     /**
@@ -127,9 +140,7 @@ class StockReservationService(
      */
     @RedisLock(key = "'stock:lock:' + #productDetailId")
     fun releaseByLock(productDetailId: Long, quantity: Int) {
-        val productDetail = productDetailRepository.findById(productDetailId)
-        productDetail.release(quantity)
-        productDetailRepository.save(productDetail)
+        redisStockRepository.increaseStock(productDetailId, quantity)
     }
 
     @Transactional

--- a/src/main/kotlin/com/hhplus/ecommerce/product/domain/StockReservationService.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/domain/StockReservationService.kt
@@ -1,5 +1,6 @@
 package com.hhplus.ecommerce.product.domain
 
+import com.hhplus.ecommerce.common.anotation.RedisLock
 import com.hhplus.ecommerce.product.domain.repository.IProductDetailRepository
 import com.hhplus.ecommerce.product.domain.repository.IRedisStockRepository
 import com.hhplus.ecommerce.product.domain.repository.IStockReservationRepository
@@ -99,6 +100,36 @@ class StockReservationService(
         val reservations = stockReservationRepository.findAllByOrderIdAndStatus(orderId, StockReservationStatus.RESERVED)
         reservations.forEach { it.status = StockReservationStatus.RELEASED }
         stockReservationRepository.saveAll(reservations)
+    }
+
+    /**
+     * Redisson 분산락 기반 재고 예약 (MySQL reservedQuantity 직접 관리)
+     * 성능 비교용: Lua 원자 스크립트 방식(reserve)과 응답시간 차이 측정
+     */
+    @RedisLock(key = "'stock:lock:' + #productDetailId")
+    fun reserveWithLock(orderId: Long, productDetailId: Long, quantity: Int): StockReservationEntity {
+        val productDetail = productDetailRepository.findById(productDetailId)
+        productDetail.reserve(quantity) // availableQuantity 검사 + reservedQuantity 증가
+        productDetailRepository.save(productDetail)
+
+        val reservation = StockReservationEntity(
+            orderId = orderId,
+            productDetailId = productDetailId,
+            quantity = quantity,
+            status = StockReservationStatus.RESERVED,
+            expiredAt = LocalDateTime.now().plusMinutes(30)
+        )
+        return stockReservationRepository.save(reservation)
+    }
+
+    /**
+     * Redisson 분산락 기반 재고 해제
+     */
+    @RedisLock(key = "'stock:lock:' + #productDetailId")
+    fun releaseByLock(productDetailId: Long, quantity: Int) {
+        val productDetail = productDetailRepository.findById(productDetailId)
+        productDetail.release(quantity)
+        productDetailRepository.save(productDetail)
     }
 
     @Transactional

--- a/src/main/kotlin/com/hhplus/ecommerce/product/domain/StockReservationService.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/domain/StockReservationService.kt
@@ -1,6 +1,7 @@
 package com.hhplus.ecommerce.product.domain
 
 import com.hhplus.ecommerce.common.anotation.RedisLock
+import com.hhplus.ecommerce.common.anotation.aspect.enums.RedisLockStrategy
 import com.hhplus.ecommerce.product.domain.repository.IProductDetailRepository
 import com.hhplus.ecommerce.product.domain.repository.IRedisStockRepository
 import com.hhplus.ecommerce.product.domain.repository.IStockReservationRepository
@@ -140,6 +141,41 @@ class StockReservationService(
      */
     @RedisLock(key = "'stock:lock:' + #productDetailId")
     fun releaseByLock(productDetailId: Long, quantity: Int) {
+        redisStockRepository.increaseStock(productDetailId, quantity)
+    }
+
+    /**
+     * Redisson 스핀락 기반 재고 예약 (성능 비교용)
+     * spinLock: 락 획득 실패 시 busy-wait(폴링) 방식으로 재시도
+     * pubSubLock: 락 해제 시 pub/sub 알림으로 대기 스레드 깨움
+     */
+    @RedisLock(key = "'stock:spin:' + #productDetailId", strategy = RedisLockStrategy.SPIN)
+    fun reserveWithSpinLock(orderId: Long, productDetailId: Long, quantity: Int): StockReservationEntity {
+        val available = redisStockRepository.getAvailableStock(productDetailId)
+        if (available < quantity) throw OutOfStockException()
+
+        redisStockRepository.decreaseStock(productDetailId, quantity)
+
+        try {
+            redisStockRepository.saveReservationInfo(orderId, productDetailId, quantity)
+            val reservation = StockReservationEntity(
+                orderId = orderId,
+                productDetailId = productDetailId,
+                quantity = quantity,
+                status = StockReservationStatus.RESERVED,
+                expiredAt = LocalDateTime.now().plusMinutes(30)
+            )
+            return stockReservationRepository.save(reservation)
+        } catch (e: Exception) {
+            logger.error("STOCK:RESERVE_WITH_SPIN:ROLLBACK - orderId={}, productDetailId={}", orderId, productDetailId, e)
+            redisStockRepository.increaseStock(productDetailId, quantity)
+            redisStockRepository.removeReservationInfo(orderId)
+            throw e
+        }
+    }
+
+    @RedisLock(key = "'stock:spin:' + #productDetailId", strategy = RedisLockStrategy.SPIN)
+    fun releaseBySpinLock(productDetailId: Long, quantity: Int) {
         redisStockRepository.increaseStock(productDetailId, quantity)
     }
 

--- a/src/main/kotlin/com/hhplus/ecommerce/product/domain/repository/IProductDetailRepository.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/domain/repository/IProductDetailRepository.kt
@@ -5,5 +5,6 @@ import com.hhplus.ecommerce.product.infrastructure.jpa.entity.ProductDetailEntit
 interface IProductDetailRepository {
     fun findById(productDetailId: Long): ProductDetailEntity
     fun findByIdForUpdate(productDetailId: Long): ProductDetailEntity = findById(productDetailId)
+    fun findAll(): List<ProductDetailEntity>
     fun save(entity: ProductDetailEntity?): ProductDetailEntity
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/product/domain/repository/IRedisStockRepository.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/domain/repository/IRedisStockRepository.kt
@@ -1,8 +1,12 @@
 package com.hhplus.ecommerce.product.domain.repository
 
 interface IRedisStockRepository {
+    // Lua 원자 스크립트 방식 (check-and-decrement 한 번에)
     fun reserve(productDetailId: Long, quantity: Int): Boolean
     fun release(productDetailId: Long, quantity: Int)
+    // Redisson 락 방식용 plain 연산 (락이 직렬화 보장)
+    fun decreaseStock(productDetailId: Long, quantity: Int)
+    fun increaseStock(productDetailId: Long, quantity: Int)
     fun getAvailableStock(productDetailId: Long): Int
     fun initializeStock(productDetailId: Long, availableQuantity: Int)
     fun saveReservationInfo(orderId: Long, productDetailId: Long, quantity: Int)

--- a/src/main/kotlin/com/hhplus/ecommerce/product/domain/repository/IRedisStockRepository.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/domain/repository/IRedisStockRepository.kt
@@ -1,0 +1,11 @@
+package com.hhplus.ecommerce.product.domain.repository
+
+interface IRedisStockRepository {
+    fun reserve(productDetailId: Long, quantity: Int): Boolean
+    fun release(productDetailId: Long, quantity: Int)
+    fun getAvailableStock(productDetailId: Long): Int
+    fun initializeStock(productDetailId: Long, availableQuantity: Int)
+    fun saveReservationInfo(orderId: Long, productDetailId: Long, quantity: Int)
+    fun getReservationInfo(orderId: Long): Map<Long, Int>
+    fun removeReservationInfo(orderId: Long)
+}

--- a/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/ProductDetailRepository.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/ProductDetailRepository.kt
@@ -11,9 +11,9 @@ class ProductDetailRepository(
     private val productDetailJpaRepository: ProductDetailJpaRepository
 ) : IProductDetailRepository {
 
-    @Transactional
+    @Transactional(readOnly = true)
     override fun findById(productDetailId: Long): ProductDetailEntity {
-        return productDetailJpaRepository.findByIdWithLock(productDetailId)
+        return productDetailJpaRepository.findById(productDetailId)
             .orElseThrow { RuntimeException("상품 상세 정보를 찾을 수 없습니다. id=$productDetailId") }
     }
 
@@ -21,6 +21,11 @@ class ProductDetailRepository(
     override fun findByIdForUpdate(productDetailId: Long): ProductDetailEntity {
         return productDetailJpaRepository.findByIdWithLock(productDetailId)
             .orElseThrow { RuntimeException("상품 상세 정보를 찾을 수 없습니다. id=$productDetailId") }
+    }
+
+    @Transactional(readOnly = true)
+    override fun findAll(): List<ProductDetailEntity> {
+        return productDetailJpaRepository.findAll()
     }
 
     @Transactional

--- a/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/event/OrderProductStockKafkaConsumer.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/event/OrderProductStockKafkaConsumer.kt
@@ -1,31 +1,16 @@
 package com.hhplus.ecommerce.product.infrastructure.event
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.hhplus.ecommerce.common.properties.OrderStockFailKafkaProperties
-import com.hhplus.ecommerce.infrastructure.kafka.KafkaProducer
-import com.hhplus.ecommerce.order.domain.OrderService
-import com.hhplus.ecommerce.outboxevent.domain.OutboxEventService
 import com.hhplus.ecommerce.outboxevent.infrastructure.event.dto.OutboxEventInfo
-import com.hhplus.ecommerce.outboxevent.infrastructure.jpa.entity.enums.OutboxEventStatus
 import com.hhplus.ecommerce.product.domain.ProductService
-import com.hhplus.ecommerce.product.domain.StockReservationService
-import com.hhplus.ecommerce.product.infrastructure.dto.OrderDetailDeletionEventRequest
 import com.hhplus.ecommerce.product.infrastructure.dto.OrderProductStockEventResponse
-import com.hhplus.ecommerce.product.infrastructure.exception.OutOfStockException
 import org.slf4j.LoggerFactory
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
-import java.util.*
 
 @Component
 class OrderProductStockKafkaConsumer(
-    private var productService: ProductService,
-    private val stockReservationService: StockReservationService,
-    private val outboxEventService: OutboxEventService,
-    private val kafkaProducer: KafkaProducer,
-    private val orderStockFailKafkaProperties: OrderStockFailKafkaProperties,
+    private val productService: ProductService,
     private val objectMapper: ObjectMapper
 ) {
     private val logger = LoggerFactory.getLogger(OrderProductStockKafkaConsumer::class.java)
@@ -46,37 +31,11 @@ class OrderProductStockKafkaConsumer(
 
         val payload = objectMapper.readValue(event.payload, OrderProductStockEventResponse::class.java)
 
-        logger.info("PRODUCT-ORDER-STOCK:KAFKA:CONSUMER: $event")
+        logger.info("PRODUCT-ORDER-STOCK:KAFKA:CONSUMER: orderId=${payload.orderId}")
 
+        // 재고 점유는 OrderFacade에서 동기적으로 처리됨 — 캐시만 무효화
         payload.products.forEach {
-            try {
-                stockReservationService.reserve(payload.orderId, it.productId, it.quantity)
-                productService.deleteCache(it.productId)
-            } catch (e: OutOfStockException) {
-                logger.warn("PRODUCT-ORDER-STOCK:KAFKA:CONSUMER: 재고 부족으로 인한 OrderDetail 삭제 => orderId=${payload.orderId}, productId=${it.productId}")
-                publishStockFailEvent(payload.orderId, it.productId)
-            } catch (e: Exception) {
-                logger.error("PRODUCT-ORDER-STOCK:KAFKA:CONSUMER: 재고 감소 중 오류 발생 => orderId=${payload.orderId}, productId=${it.productId}", e)
-                publishStockFailEvent(payload.orderId, it.productId)
-            }
+            productService.deleteCache(it.productId)
         }
-    }
-
-    private fun publishStockFailEvent(orderId: Long, productId: Long) {
-        val orderStockFailEvent = OrderDetailDeletionEventRequest.of(orderId, productId)
-        val outboxEvent = OutboxEventInfo(
-            id = UUID.randomUUID(),
-            groupId = orderStockFailKafkaProperties.groupId,
-            topic = orderStockFailKafkaProperties.topic,
-            payload = objectMapper.writeValueAsString(orderStockFailEvent),
-            eventType = "OrderStockFail",
-            schemaVersion = "1"
-        )
-
-        val outboxEntity = outboxEvent.toEntity()
-        outboxEntity.status = OutboxEventStatus.PUBLISH
-        outboxEventService.insertOrUpdate(outboxEntity)
-
-        kafkaProducer.sendOutboxEvent(outboxEvent)
     }
 }

--- a/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/jpa/entity/ProductDetailEntity.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/jpa/entity/ProductDetailEntity.kt
@@ -51,6 +51,11 @@ class ProductDetailEntity(
         quantity -= amount
     }
 
+    fun decreaseQuantity(amount: Int) {
+        require(amount <= quantity) { "감소 수량($amount)이 실재고($quantity)를 초과합니다." }
+        quantity -= amount
+    }
+
     fun release(amount: Int) {
         require(amount <= reservedQuantity) { "release 수량($amount)이 예약 수량($reservedQuantity)을 초과합니다." }
         reservedQuantity -= amount

--- a/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/redis/RedisStockRepository.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/redis/RedisStockRepository.kt
@@ -40,6 +40,14 @@ class RedisStockRepository(
         )
     }
 
+    override fun decreaseStock(productDetailId: Long, quantity: Int) {
+        redissonClient.getAtomicLong("$AVAILABLE_KEY_PREFIX$productDetailId").addAndGet(-quantity.toLong())
+    }
+
+    override fun increaseStock(productDetailId: Long, quantity: Int) {
+        redissonClient.getAtomicLong("$AVAILABLE_KEY_PREFIX$productDetailId").addAndGet(quantity.toLong())
+    }
+
     override fun getAvailableStock(productDetailId: Long): Int {
         val key = "$AVAILABLE_KEY_PREFIX$productDetailId"
         return redissonClient.getAtomicLong(key).get().toInt()

--- a/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/redis/RedisStockRepository.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/redis/RedisStockRepository.kt
@@ -1,0 +1,71 @@
+package com.hhplus.ecommerce.product.infrastructure.redis
+
+import com.hhplus.ecommerce.product.domain.repository.IRedisStockRepository
+import org.redisson.api.RedissonClient
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class RedisStockRepository(
+    private val redissonClient: RedissonClient
+) : IRedisStockRepository {
+
+    private val logger = LoggerFactory.getLogger(RedisStockRepository::class.java)
+
+    companion object {
+        private const val AVAILABLE_KEY_PREFIX = "stock:available:"
+        private const val RESERVATION_KEY_PREFIX = "stock:reservation:"
+    }
+
+    override fun reserve(productDetailId: Long, quantity: Int): Boolean {
+        val key = "$AVAILABLE_KEY_PREFIX$productDetailId"
+        val result = redissonClient.getScript(org.redisson.client.codec.StringCodec.INSTANCE).eval<Long>(
+            org.redisson.api.RScript.Mode.READ_WRITE,
+            StockLuaScripts.RESERVE,
+            org.redisson.api.RScript.ReturnType.INTEGER,
+            listOf(key),
+            quantity.toString()
+        )
+        return result == 1L
+    }
+
+    override fun release(productDetailId: Long, quantity: Int) {
+        val key = "$AVAILABLE_KEY_PREFIX$productDetailId"
+        redissonClient.getScript(org.redisson.client.codec.StringCodec.INSTANCE).eval<Long>(
+            org.redisson.api.RScript.Mode.READ_WRITE,
+            StockLuaScripts.RELEASE,
+            org.redisson.api.RScript.ReturnType.INTEGER,
+            listOf(key),
+            quantity.toString()
+        )
+    }
+
+    override fun getAvailableStock(productDetailId: Long): Int {
+        val key = "$AVAILABLE_KEY_PREFIX$productDetailId"
+        return redissonClient.getAtomicLong(key).get().toInt()
+    }
+
+    override fun initializeStock(productDetailId: Long, availableQuantity: Int) {
+        val key = "$AVAILABLE_KEY_PREFIX$productDetailId"
+        redissonClient.getAtomicLong(key).set(availableQuantity.toLong())
+        logger.debug("REDIS:STOCK:INIT - productDetailId={}, availableQuantity={}", productDetailId, availableQuantity)
+    }
+
+    override fun saveReservationInfo(orderId: Long, productDetailId: Long, quantity: Int) {
+        val key = "$RESERVATION_KEY_PREFIX$orderId"
+        redissonClient.getMap<String, String>(key).put(productDetailId.toString(), quantity.toString())
+    }
+
+    override fun getReservationInfo(orderId: Long): Map<Long, Int> {
+        val key = "$RESERVATION_KEY_PREFIX$orderId"
+        return redissonClient.getMap<String, String>(key)
+            .readAllMap()
+            .mapKeys { it.key.toLong() }
+            .mapValues { it.value.toInt() }
+    }
+
+    override fun removeReservationInfo(orderId: Long) {
+        val key = "$RESERVATION_KEY_PREFIX$orderId"
+        redissonClient.getMap<String, String>(key).delete()
+    }
+}

--- a/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/redis/RedisStockSyncScheduler.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/redis/RedisStockSyncScheduler.kt
@@ -1,0 +1,39 @@
+package com.hhplus.ecommerce.product.infrastructure.redis
+
+import com.hhplus.ecommerce.product.domain.repository.IProductDetailRepository
+import com.hhplus.ecommerce.product.domain.repository.IRedisStockRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class RedisStockSyncScheduler(
+    private val productDetailRepository: IProductDetailRepository,
+    private val redisStockRepository: IRedisStockRepository
+) {
+    private val logger = LoggerFactory.getLogger(RedisStockSyncScheduler::class.java)
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun initializeOnStartup() {
+        logger.info("REDIS:STOCK:INIT - Redis 재고 초기화 시작")
+        syncAllStock()
+        logger.info("REDIS:STOCK:INIT - Redis 재고 초기화 완료")
+    }
+
+    @Scheduled(fixedDelay = 600_000) // 10분마다 재조정
+    fun reconcile() {
+        logger.info("REDIS:STOCK:RECONCILE - Redis 재고 재조정 시작")
+        syncAllStock()
+        logger.info("REDIS:STOCK:RECONCILE - Redis 재고 재조정 완료")
+    }
+
+    private fun syncAllStock() {
+        val productDetails = productDetailRepository.findAll()
+        productDetails.forEach { detail ->
+            redisStockRepository.initializeStock(detail.id, detail.availableQuantity)
+        }
+        logger.info("REDIS:STOCK:SYNC - {}개 상품 재고 동기화 완료", productDetails.size)
+    }
+}

--- a/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/redis/StockLuaScripts.kt
+++ b/src/main/kotlin/com/hhplus/ecommerce/product/infrastructure/redis/StockLuaScripts.kt
@@ -1,0 +1,30 @@
+package com.hhplus.ecommerce.product.infrastructure.redis
+
+object StockLuaScripts {
+
+    /**
+     * 가용 재고 검증 + 차감을 원자적으로 수행
+     * KEYS[1]: stock:available:{productDetailId}
+     * ARGV[1]: 요청 수량
+     * 반환: 1 (성공), 0 (재고 부족)
+     */
+    val RESERVE = """
+        local available = tonumber(redis.call('GET', KEYS[1]) or '0')
+        local requested = tonumber(ARGV[1])
+        if available >= requested then
+            redis.call('DECRBY', KEYS[1], requested)
+            return 1
+        end
+        return 0
+    """.trimIndent()
+
+    /**
+     * 가용 재고 복원
+     * KEYS[1]: stock:available:{productDetailId}
+     * ARGV[1]: 복원 수량
+     */
+    val RELEASE = """
+        redis.call('INCRBY', KEYS[1], tonumber(ARGV[1]))
+        return 1
+    """.trimIndent()
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -4,6 +4,9 @@ spring:
   sql:
     init:
       mode: always
+  jpa:
+    properties:
+      "[hibernate.hbm2ddl.halt_on_error]": "false"
   data:
     mongodb:
       uri: mongodb://ironjin:1234@localhost:27017/hhplus?authSource=admin

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,5 +39,5 @@ logging:
   level:
     root: INFO                    # 기본 로그 레벨 (INFO)
     # org.hibernate.SQL: DEBUG
-    org.springframework.web: DEBUG # 특정 패키지에 대한 로그 레벨 (예: Spring MVC 관련)
+    org.springframework.web: INFO # Spring MVC 관련 DEBUG 로그 억제
     com.hhplus.ecommerce: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,4 +40,5 @@ logging:
     root: INFO                    # 기본 로그 레벨 (INFO)
     # org.hibernate.SQL: DEBUG
     org.springframework.web: INFO # Spring MVC 관련 DEBUG 로그 억제
+    org.springframework.kafka: WARN # Kafka partition assigned 등 INFO 로그 억제
     com.hhplus.ecommerce: DEBUG

--- a/src/main/resources/sql/database-data.sql
+++ b/src/main/resources/sql/database-data.sql
@@ -57,7 +57,7 @@ INSERT INTO product_detail (product_id, product_option_id, quantity, reserved_qu
 VALUES (
            (SELECT id FROM product WHERE name = '가방'),
            (SELECT id FROM product_option WHERE option_name = 'Color' AND option_value = 'Red'),
-           50,
+           10000, -- perf_order.js: 초당 100건 x 60초 = 최대 6,000건 커버
            0,
            CURRENT_TIMESTAMP,
            CURRENT_TIMESTAMP
@@ -67,7 +67,7 @@ INSERT INTO product_detail (product_id, product_option_id, quantity, reserved_qu
 VALUES (
            (SELECT id FROM product WHERE name = '신발'),
            (SELECT id FROM product_option WHERE option_name = 'Color' AND option_value = 'Red'),
-           10,
+           50, -- perf-order.js: VU 12개 커버
            0,
            CURRENT_TIMESTAMP,
            CURRENT_TIMESTAMP

--- a/src/test/kotlin/com/hhplus/ecommerce/OrderConcurrencyTest.kt
+++ b/src/test/kotlin/com/hhplus/ecommerce/OrderConcurrencyTest.kt
@@ -1,13 +1,14 @@
 package com.hhplus.ecommerce
 
 import com.hhplus.ecommerce.common.config.IntegrationConfig
-import com.hhplus.ecommerce.common.enums.StateYn
+import com.hhplus.ecommerce.order.common.OrderStatus
 import com.hhplus.ecommerce.order.infrastructure.OrderRepository
-import com.hhplus.ecommerce.product.infrastructure.jpa.ProductDetailJpaRepository
+import com.hhplus.ecommerce.product.domain.repository.IRedisStockRepository
 import com.hhplus.ecommerce.order.usecase.OrderFacade
 import com.hhplus.ecommerce.order.usecase.dto.OrderCreation
 import com.hhplus.ecommerce.order.usecase.dto.OrderDetailCreation
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -20,10 +21,20 @@ class OrderConcurrencyTest: IntegrationConfig() {
     private lateinit var orderFacade: OrderFacade
 
     @Autowired
-    private lateinit var productRepository: ProductDetailJpaRepository
+    private lateinit var redisStockRepository: IRedisStockRepository
 
     @Autowired
     private lateinit var orderRepository: OrderRepository
+
+    private val productDetailId = 4L
+
+    @BeforeEach
+    fun setUp() {
+        // SQL 데이터: product_detail.id=4 ('책') quantity=1
+        // RedisStockSyncScheduler가 ApplicationReadyEvent로 초기화하지만,
+        // 테스트 간 Redis 상태 격리를 위해 명시적으로 재초기화
+        redisStockRepository.initializeStock(productDetailId, 1)
+    }
 
     @DisplayName("재고가 하나 남은 상품에 대해 동시 신청을 하게되면, 1명만 성공한다")
     @Test
@@ -32,62 +43,47 @@ class OrderConcurrencyTest: IntegrationConfig() {
         val errorUserIds = Collections.synchronizedList(mutableListOf<Long>())
         val totalRequests = 5
 
-        // 동시 요청을 대기할 Latch 설정
         val readyLatch = CountDownLatch(1)
         val completeLatch = CountDownLatch(totalRequests)
 
-        // 스레드 풀 생성
         val executorService = Executors.newFixedThreadPool(totalRequests)
 
-        // 5개의 요청을 비동기로 생성하여 실행
         for (i in 1..totalRequests) {
             executorService.submit {
                 try {
-                    // 모든 스레드가 준비될 때까지 대기
                     readyLatch.await()
 
-                    val detailCommand = OrderDetailCreation(4L, 1, 100)
-
-                    // 요청마다 같은 상품 ID를 사용하여 LectureCommandData 생성
+                    val detailCommand = OrderDetailCreation(productDetailId, 1, 100)
                     val command = OrderCreation(i.toLong(), listOf(detailCommand))
 
-                    // 주문 신청
                     orderFacade.order(command)
                 } catch (e: Exception) {
                     println("$i -> ${e.message}")
                 } finally {
-                    // 요청 완료 시 Latch 카운트 감소
                     completeLatch.countDown()
                 }
             }
         }
 
-        // 모든 스레드가 시작되기를 준비한 후 동시에 시작
-        readyLatch.countDown() // 모든 스레드가 동시에 시작하도록 Latch 해제
-
-        // 모든 요청이 완료될 때까지 대기
+        readyLatch.countDown()
         completeLatch.await()
-
-        // 스레드 풀 종료
         executorService.shutdown()
 
         Thread.sleep(500)
 
-        val productDetail = productRepository.findById(4).get()
+        val availableStock = redisStockRepository.getAvailableStock(productDetailId)
 
         for (i in 1..totalRequests) {
             val orderInfo = orderRepository.findById(i.toLong())
-            if (StateYn.Y == orderInfo.delYn) {
+            if (OrderStatus.CANCELED == orderInfo.status) {
                 errorUserIds.add(i.toLong())
             } else {
                 successUserIds.add(i.toLong())
             }
         }
 
-        assertEquals(productDetail.reservedQuantity, 1) // 예약 재고 수량이 1개인지 검사
-        assertEquals(successUserIds.size, 1) // 5건의 요청중 가장 먼저 처리된건이 성공한다.
-        assertEquals(errorUserIds.size, 4) // 나머지 요청은 실패한다.
+        assertEquals(0, availableStock) // 재고 1개가 모두 예약되어 가용 재고 = 0
+        assertEquals(1, successUserIds.size) // 5건 중 1건만 성공
+        assertEquals(4, errorUserIds.size) // 나머지 4건은 실패
     }
-
-
 }

--- a/src/test/kotlin/com/hhplus/ecommerce/domain/product/StockReservationIntegrationTest.kt
+++ b/src/test/kotlin/com/hhplus/ecommerce/domain/product/StockReservationIntegrationTest.kt
@@ -3,9 +3,9 @@ package com.hhplus.ecommerce.domain.product
 import com.hhplus.ecommerce.common.config.IntegrationConfig
 import com.hhplus.ecommerce.product.domain.StockReservationService
 import com.hhplus.ecommerce.product.domain.repository.IProductDetailRepository
+import com.hhplus.ecommerce.product.domain.repository.IRedisStockRepository
 import com.hhplus.ecommerce.product.infrastructure.exception.OutOfStockException
 import com.hhplus.ecommerce.product.infrastructure.jpa.entity.ProductDetailEntity
-import com.hhplus.ecommerce.product.infrastructure.jpa.entity.StockReservationStatus
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -25,6 +25,9 @@ class StockReservationIntegrationTest : IntegrationConfig() {
     @Autowired
     private lateinit var productDetailRepository: IProductDetailRepository
 
+    @Autowired
+    private lateinit var redisStockRepository: IRedisStockRepository
+
     private lateinit var productDetailEntity: ProductDetailEntity
 
     @BeforeEach
@@ -36,6 +39,8 @@ class StockReservationIntegrationTest : IntegrationConfig() {
                 quantity = 10
             )
         )
+        // Redis 재고 초기화
+        redisStockRepository.initializeStock(productDetailEntity.id, productDetailEntity.quantity)
     }
 
     @DisplayName("동시에 여러 요청이 reserve를 호출해도 재고 한도를 초과하지 않는다.")
@@ -70,14 +75,14 @@ class StockReservationIntegrationTest : IntegrationConfig() {
         executor.shutdown()
 
         // Then
-        val refreshed = productDetailRepository.findById(productDetailId)
+        val availableAfter = redisStockRepository.getAvailableStock(productDetailId)
         assertTrue(successResults.size <= 10, "성공한 예약 수(${successResults.size})가 재고(10)를 초과해서는 안 된다.")
-        assertEquals(successResults.size, refreshed.reservedQuantity)
+        assertEquals(10 - successResults.size, availableAfter, "가용 재고 = 초기 재고 - 성공한 예약 수")
     }
 
-    @DisplayName("reserve 후 commit하면 실재고가 감소하고 예약재고가 0으로 돌아온다.")
+    @DisplayName("reserve 후 commit하면 실재고가 감소하고 예약재고 필드는 0으로 유지된다.")
     @Test
-    fun commitAfterReserveDecreasesActualStockAndClearsReservedQuantity() {
+    fun commitAfterReserveDecreasesActualStock() {
         // Given
         val orderId = 200L
         val productDetailId = productDetailEntity.id
@@ -93,37 +98,37 @@ class StockReservationIntegrationTest : IntegrationConfig() {
         assertEquals(7, refreshed.quantity)
     }
 
-    @DisplayName("reserve 후 release하면 availableQuantity가 원래대로 복원된다.")
+    @DisplayName("reserve 후 release하면 Redis 가용 재고가 원래대로 복원된다.")
     @Test
-    fun releaseAfterReserveRestoresAvailableQuantityToOriginal() {
+    fun releaseAfterReserveRestoresRedisAvailableStock() {
         // Given
         val orderId = 300L
         val productDetailId = productDetailEntity.id
         val quantity = 4
         stockReservationService.reserve(orderId, productDetailId, quantity)
 
+        val availableAfterReserve = redisStockRepository.getAvailableStock(productDetailId)
+        assertEquals(6, availableAfterReserve)
+
         // When
         stockReservationService.release(orderId)
 
         // Then
-        val refreshed = productDetailRepository.findById(productDetailId)
-        assertEquals(0, refreshed.reservedQuantity)
-        assertEquals(10, refreshed.availableQuantity)
+        val availableAfterRelease = redisStockRepository.getAvailableStock(productDetailId)
+        assertEquals(10, availableAfterRelease)
     }
 
-    @DisplayName("expireOverdue는 만료 기한이 지난 RESERVED 항목만 처리하고 다른 상태의 항목은 건드리지 않는다.")
+    @DisplayName("expireOverdue는 만료 기한이 지난 RESERVED 항목만 처리하고 Redis 재고를 복원한다.")
     @Test
-    fun expireOverdueOnlyProcessesExpiredReservedItemsAndIgnoresOtherStatuses() {
+    fun expireOverdueOnlyProcessesExpiredReservedItemsAndRestoresRedisStock() {
         // Given
         val activeOrderId = 400L
         val expiredOrderId = 401L
         val committedOrderId = 402L
         val productDetailId = productDetailEntity.id
 
-        // 활성 예약 (만료되지 않음)
         stockReservationService.reserve(activeOrderId, productDetailId, 1)
 
-        // 만료된 예약 직접 삽입 (expiredAt을 과거로 설정)
         stockReservationService.reserveWithExpiry(
             orderId = expiredOrderId,
             productDetailId = productDetailId,
@@ -131,18 +136,17 @@ class StockReservationIntegrationTest : IntegrationConfig() {
             expiredAt = java.time.LocalDateTime.now().minusMinutes(1)
         )
 
-        // 커밋된 예약
         stockReservationService.reserve(committedOrderId, productDetailId, 1)
         stockReservationService.commit(committedOrderId)
 
-        val reservedQuantityBeforeExpire = productDetailRepository.findById(productDetailId).reservedQuantity
+        val availableBeforeExpire = redisStockRepository.getAvailableStock(productDetailId)
 
         // When
         val expiredCount = stockReservationService.expireOverdue()
 
         // Then
-        val refreshed = productDetailRepository.findById(productDetailId)
+        val availableAfterExpire = redisStockRepository.getAvailableStock(productDetailId)
         assertEquals(1, expiredCount, "만료 기한이 지난 RESERVED 항목 1개만 처리되어야 한다.")
-        assertEquals(reservedQuantityBeforeExpire - 2, refreshed.reservedQuantity)
+        assertEquals(availableBeforeExpire + 2, availableAfterExpire, "만료된 2개 예약 재고가 Redis에 복원되어야 한다.")
     }
 }

--- a/src/test/kotlin/com/hhplus/ecommerce/domain/product/StockReservationServiceTest.kt
+++ b/src/test/kotlin/com/hhplus/ecommerce/domain/product/StockReservationServiceTest.kt
@@ -1,19 +1,20 @@
 package com.hhplus.ecommerce.domain.product
 
 import com.hhplus.ecommerce.product.domain.StockReservationService
+import com.hhplus.ecommerce.product.domain.repository.IProductDetailRepository
+import com.hhplus.ecommerce.product.domain.repository.IRedisStockRepository
 import com.hhplus.ecommerce.product.domain.repository.IStockReservationRepository
 import com.hhplus.ecommerce.product.infrastructure.exception.OutOfStockException
 import com.hhplus.ecommerce.product.infrastructure.jpa.entity.ProductDetailEntity
 import com.hhplus.ecommerce.product.infrastructure.jpa.entity.StockReservationEntity
 import com.hhplus.ecommerce.product.infrastructure.jpa.entity.StockReservationStatus
-import com.hhplus.ecommerce.product.domain.repository.IProductDetailRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
-import org.mockito.BDDMockito.then
+import org.mockito.BDDMockito.willDoNothing
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import java.time.LocalDateTime
@@ -28,29 +29,25 @@ class StockReservationServiceTest {
     @Mock
     private lateinit var productDetailRepository: IProductDetailRepository
 
+    @Mock
+    private lateinit var redisStockRepository: IRedisStockRepository
+
     private lateinit var stockReservationService: StockReservationService
 
     @BeforeEach
     fun before() {
-        stockReservationService = StockReservationService(stockReservationRepository, productDetailRepository)
+        stockReservationService = StockReservationService(stockReservationRepository, productDetailRepository, redisStockRepository)
     }
 
-    @DisplayName("reserve 호출 시 StockReservationEntity가 RESERVED 상태로 생성되고 ProductDetail의 reservedQuantity가 증가한다.")
+    @DisplayName("reserve 호출 시 Redis에서 재고를 차감하고 StockReservationEntity가 RESERVED 상태로 생성된다.")
     @Test
-    fun reserveCreatesReservedEntityAndIncreasesReservedQuantity() {
+    fun reserveCreatesReservedEntityViaRedis() {
         // Given
         val orderId = 1L
         val productDetailId = 10L
         val quantity = 3
 
-        val productDetailEntity = ProductDetailEntity(
-            id = productDetailId,
-            productId = 1L,
-            productOptionId = 1L,
-            quantity = 10
-        )
-
-        given(productDetailRepository.findById(productDetailId)).willReturn(productDetailEntity)
+        given(redisStockRepository.reserve(productDetailId, quantity)).willReturn(true)
 
         val savedReservation = StockReservationEntity(
             id = 1L,
@@ -58,7 +55,7 @@ class StockReservationServiceTest {
             productDetailId = productDetailId,
             quantity = quantity,
             status = StockReservationStatus.RESERVED,
-            expiredAt = LocalDateTime.now().plusMinutes(10)
+            expiredAt = LocalDateTime.now().plusMinutes(30)
         )
         given(stockReservationRepository.save(org.mockito.ArgumentMatchers.any())).willReturn(savedReservation)
 
@@ -72,7 +69,23 @@ class StockReservationServiceTest {
         assertEquals(quantity, result.quantity)
     }
 
-    @DisplayName("commit 호출 시 해당 orderId의 예약이 COMMITTED 상태로 전환되고 실재고가 차감된다.")
+    @DisplayName("reserve 호출 시 Redis 재고가 부족하면 OutOfStockException이 발생한다.")
+    @Test
+    fun reserveThrowsOutOfStockWhenRedisStockInsufficient() {
+        // Given
+        val orderId = 1L
+        val productDetailId = 10L
+        val quantity = 5
+
+        given(redisStockRepository.reserve(productDetailId, quantity)).willReturn(false)
+
+        // When & Then
+        assertThrows<OutOfStockException> {
+            stockReservationService.reserve(orderId, productDetailId, quantity)
+        }
+    }
+
+    @DisplayName("commit 호출 시 예약이 COMMITTED 상태로 전환되고 MySQL 실재고가 차감된다.")
     @Test
     fun commitTransitionsReservationToCommittedAndDecreasesActualStock() {
         // Given
@@ -86,7 +99,6 @@ class StockReservationServiceTest {
             productOptionId = 1L,
             quantity = 10
         )
-        productDetailEntity.reserve(quantity)
 
         val reservation = StockReservationEntity(
             id = 1L,
@@ -94,37 +106,28 @@ class StockReservationServiceTest {
             productDetailId = productDetailId,
             quantity = quantity,
             status = StockReservationStatus.RESERVED,
-            expiredAt = LocalDateTime.now().plusMinutes(10)
+            expiredAt = LocalDateTime.now().plusMinutes(30)
         )
 
         given(stockReservationRepository.findAllByOrderIdAndStatus(orderId, StockReservationStatus.RESERVED))
             .willReturn(listOf(reservation))
-        given(productDetailRepository.findById(productDetailId)).willReturn(productDetailEntity)
+        given(productDetailRepository.findByIdForUpdate(productDetailId)).willReturn(productDetailEntity)
 
         // When
         stockReservationService.commit(orderId)
 
         // Then
         assertEquals(StockReservationStatus.COMMITTED, reservation.status)
-        assertEquals(0, productDetailEntity.reservedQuantity)
         assertEquals(7, productDetailEntity.quantity)
     }
 
-    @DisplayName("release 호출 시 해당 orderId의 예약이 RELEASED 상태로 전환되고 예약재고가 복원된다.")
+    @DisplayName("release 호출 시 Redis 재고가 복원되고 예약이 RELEASED 상태로 전환된다.")
     @Test
-    fun releaseTransitionsReservationToReleasedAndRestoresReservedStock() {
+    fun releaseRestoresRedisStockAndTransitionsToReleased() {
         // Given
         val orderId = 1L
         val productDetailId = 10L
         val quantity = 4
-
-        val productDetailEntity = ProductDetailEntity(
-            id = productDetailId,
-            productId = 1L,
-            productOptionId = 1L,
-            quantity = 10
-        )
-        productDetailEntity.reserve(quantity)
 
         val reservation = StockReservationEntity(
             id = 1L,
@@ -132,36 +135,26 @@ class StockReservationServiceTest {
             productDetailId = productDetailId,
             quantity = quantity,
             status = StockReservationStatus.RESERVED,
-            expiredAt = LocalDateTime.now().plusMinutes(10)
+            expiredAt = LocalDateTime.now().plusMinutes(30)
         )
 
+        given(redisStockRepository.getReservationInfo(orderId)).willReturn(mapOf(productDetailId to quantity))
         given(stockReservationRepository.findAllByOrderIdAndStatus(orderId, StockReservationStatus.RESERVED))
             .willReturn(listOf(reservation))
-        given(productDetailRepository.findById(productDetailId)).willReturn(productDetailEntity)
 
         // When
         stockReservationService.release(orderId)
 
         // Then
         assertEquals(StockReservationStatus.RELEASED, reservation.status)
-        assertEquals(0, productDetailEntity.reservedQuantity)
-        assertEquals(10, productDetailEntity.availableQuantity)
     }
 
-    @DisplayName("expireOverdue 호출 시 만료된 예약이 EXPIRED 처리되고 예약재고가 반납된다.")
+    @DisplayName("expireOverdue 호출 시 만료된 예약이 EXPIRED 처리되고 Redis 재고가 복원된다.")
     @Test
-    fun expireOverdueProcessesExpiredReservationsAndReturnsReservedStock() {
+    fun expireOverdueProcessesExpiredReservationsAndRestoresRedisStock() {
         // Given
         val productDetailId = 10L
         val quantity = 2
-
-        val productDetailEntity = ProductDetailEntity(
-            id = productDetailId,
-            productId = 1L,
-            productOptionId = 1L,
-            quantity = 10
-        )
-        productDetailEntity.reserve(quantity)
 
         val expiredReservation = StockReservationEntity(
             id = 1L,
@@ -176,7 +169,6 @@ class StockReservationServiceTest {
             org.mockito.ArgumentMatchers.eq(StockReservationStatus.RESERVED),
             org.mockito.ArgumentMatchers.any()
         )).willReturn(listOf(expiredReservation))
-        given(productDetailRepository.findById(productDetailId)).willReturn(productDetailEntity)
 
         // When
         val expiredCount = stockReservationService.expireOverdue()
@@ -184,7 +176,6 @@ class StockReservationServiceTest {
         // Then
         assertEquals(1, expiredCount)
         assertEquals(StockReservationStatus.EXPIRED, expiredReservation.status)
-        assertEquals(0, productDetailEntity.reservedQuantity)
     }
 
     @DisplayName("이미 COMMITTED 상태의 예약에 commit을 시도하면 예외가 발생한다.")

--- a/src/test/kotlin/com/hhplus/ecommerce/facade/OrderFacadeTest.kt
+++ b/src/test/kotlin/com/hhplus/ecommerce/facade/OrderFacadeTest.kt
@@ -2,9 +2,6 @@ package com.hhplus.ecommerce.facade
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.hhplus.ecommerce.balance.domain.BalanceService
-import com.hhplus.ecommerce.cart.domain.CartService
-import com.hhplus.ecommerce.cart.domain.dto.CartResult
-import com.hhplus.ecommerce.cart.domain.dto.ProductIdCartQuery
 import com.hhplus.ecommerce.common.properties.ProductStockKafkaProperties
 import com.hhplus.ecommerce.order.common.OrderStatus
 import com.hhplus.ecommerce.order.domain.OrderService
@@ -13,6 +10,7 @@ import com.hhplus.ecommerce.order.domain.dto.OrderDetailCreationCommand
 import com.hhplus.ecommerce.order.domain.dto.OrderDetailResult
 import com.hhplus.ecommerce.order.domain.dto.OrderResult
 import com.hhplus.ecommerce.product.domain.ProductService
+import com.hhplus.ecommerce.product.domain.StockReservationService
 import com.hhplus.ecommerce.product.domain.dto.ProductDetailQuery
 import com.hhplus.ecommerce.product.domain.dto.ProductDetailResult
 import com.hhplus.ecommerce.user.domain.UserService
@@ -42,6 +40,10 @@ class OrderFacadeTest {
     @Mock
     private lateinit var orderService: OrderService
     @Mock
+    private lateinit var stockReservationService: StockReservationService
+    @Mock
+    private lateinit var productService: ProductService
+    @Mock
     private lateinit var applicationEventPublisher: ApplicationEventPublisher
     @Mock
     private lateinit var objectMapper: ObjectMapper
@@ -57,7 +59,7 @@ class OrderFacadeTest {
             topic = "test-product-topic"
         }
         BDDMockito.given(objectMapper.writeValueAsString(ArgumentMatchers.any())).willReturn("{}")
-        orderFacade = OrderFacade(userService, balanceService, orderService, applicationEventPublisher, productStockKafkaProperties, objectMapper, notificationEventPublisher)
+        orderFacade = OrderFacade(userService, balanceService, orderService, stockReservationService, productService, applicationEventPublisher, productStockKafkaProperties, objectMapper, notificationEventPublisher)
     }
 
     @DisplayName("주문 정합성 테스트")
@@ -105,6 +107,7 @@ class OrderFacadeTest {
         )
 
         BDDMockito.given(orderService.order(orderCommand)).willReturn(orderResult)
+        BDDMockito.given(productService.getProductDetail(ProductDetailQuery(productResult.productId))).willReturn(productResult)
 
         val orderDetailCreation = OrderDetailCreation(
             productId = productResult.productId,


### PR DESCRIPTION
## 변경사항

- **Redis 기반 재고 예약 시스템 전환**: 트랜잭션 밖에서 Redis `stock:available` 키를 직접 관리하는 방식으로 재고 점유 로직 전환
- **Redisson 분산락 기반 주문 엔드포인트 추가**: Lua 스크립트 방식과 성능 비교를 위한 엔드포인트 추가
- **Redisson 스핀락 기반 주문 엔드포인트 추가**: PubSub 락 / 스핀락 / Lua 스크립트 3-way 성능 비교 구성
- **PubSubLockSupporter 락 해제 누락 버그 수정**: 예외 발생 시 unlock이 누락되던 버그 수정
- **K6 성능 테스트 전환**: 초당 고정 부하(constant arrival rate) 방식으로 성능 테스트 시나리오 개선

## 성능 비교 구성 (3-way)

| 방식 | 엔드포인트 |
|---|---|
| PubSub 분산락 (Redisson) | `/api/v1/orders` |
| 스핀락 (Redisson) | `/api/v1/orders/spin` |
| Lua 스크립트 | `/api/v1/orders/lua` |

## 체크리스트

- [x] PubSubLockSupporter 락 해제 버그 수정 완료
- [x] Redis stock:available 직접 관리로 재고 예약 전환
- [x] K6 성능 테스트 시나리오 (초당 고정 부하 방식) 업데이트
- [x] 3-way 성능 비교용 엔드포인트 구성 완료